### PR TITLE
use serialized_size<T>() in serialization targets (buf, file)

### DIFF
--- a/include/cista/serialization.h
+++ b/include/cista/serialization.h
@@ -9,6 +9,7 @@
 #include "cista/decay.h"
 #include "cista/offset_t.h"
 #include "cista/reflection/for_each_field.h"
+#include "cista/serialized_size.h"
 #include "cista/targets/buf.h"
 #include "cista/targets/file.h"
 
@@ -23,11 +24,6 @@ struct pending_offset {
   offset_t pos_;
   pointer_type type_;
 };
-
-template <typename T>
-static inline constexpr size_t serialized_size() {
-  return sizeof(decay_t<T>);
-}
 
 template <typename Target>
 struct serialization_context {

--- a/include/cista/serialized_size.h
+++ b/include/cista/serialized_size.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cinttypes>
+
+#include "cista/decay.h"
+
+namespace cista {
+
+template <typename T>
+static inline constexpr size_t serialized_size() {
+  return sizeof(decay_t<T>);
+}
+
+}  // namespace cista

--- a/include/cista/targets/buf.h
+++ b/include/cista/targets/buf.h
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "cista/offset_t.h"
+#include "cista/serialized_size.h"
 #include "cista/verify.h"
 
 namespace cista {
@@ -18,8 +19,9 @@ struct buf {
 
   template <typename T>
   void write(offset_t const pos, T const& val) {
-    cista_verify(buf_.size() >= pos + sizeof(val), "out of bounds write");
-    std::memcpy(&buf_[pos], &val, sizeof(val));
+    cista_verify(buf_.size() >= pos + serialized_size<T>(),
+                 "out of bounds write");
+    std::memcpy(&buf_[pos], &val, serialized_size<T>());
   }
 
   offset_t write(void const* ptr, offset_t const size, offset_t alignment = 0) {

--- a/include/cista/targets/file.h
+++ b/include/cista/targets/file.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "cista/offset_t.h"
+#include "cista/serialized_size.h"
 #include "cista/verify.h"
 
 #ifdef _MSC_VER
@@ -36,8 +37,8 @@ struct sfile {
   void write(offset_t const pos, T const& val) {
     std::fseek(f_, static_cast<long>(pos), SEEK_SET);
     auto const w = std::fwrite(reinterpret_cast<unsigned char const*>(&val), 1,
-                               sizeof(val), f_);
-    cista_verify(w == sizeof(val), "write error");
+                               serialized_size<T>(), f_);
+    cista_verify(w == serialized_size<T>(), "write error");
   }
 
   offset_t write(void const* ptr, offset_t const size, offset_t alignment) {


### PR DESCRIPTION
See #17 