### PR TITLE
mark move_ctor and move_assign as noexcept

### DIFF
--- a/include/cista/containers/hash_storage.h
+++ b/include/cista/containers/hash_storage.h
@@ -250,7 +250,7 @@ struct hash_storage {
     insert(init.begin(), init.end());
   }
 
-  hash_storage(hash_storage&& other)
+  hash_storage(hash_storage&& other) noexcept
       : entries_{other.entries_},
         ctrl_{other.ctrl_},
         size_{other.size_},
@@ -277,7 +277,7 @@ struct hash_storage {
     growth_left_ -= other.size();
   }
 
-  hash_storage& operator=(hash_storage&& other) {
+  hash_storage& operator=(hash_storage&& other) noexcept {
     entries_ = other.entries_;
     ctrl_ = other.ctrl_;
     size_ = other.size_;

--- a/include/cista/containers/offset_ptr.h
+++ b/include/cista/containers/offset_ptr.h
@@ -22,12 +22,12 @@ struct offset_ptr {
   }
 
   offset_ptr(offset_ptr const& o) : offset_{ptr_to_offset(o.get())} {}
-  offset_ptr(offset_ptr&& o) : offset_{ptr_to_offset(o.get())} {}
+  offset_ptr(offset_ptr&& o) noexcept : offset_{ptr_to_offset(o.get())} {}
   offset_ptr& operator=(offset_ptr const& o) {
     offset_ = ptr_to_offset(o.get());
     return *this;
   }
-  offset_ptr& operator=(offset_ptr&& o) {
+  offset_ptr& operator=(offset_ptr&& o) noexcept {
     offset_ = ptr_to_offset(o.get());
     return *this;
   }

--- a/include/cista/containers/unique_ptr.h
+++ b/include/cista/containers/unique_ptr.h
@@ -21,13 +21,13 @@ struct basic_unique_ptr {
   basic_unique_ptr(basic_unique_ptr const&) = delete;
   basic_unique_ptr& operator=(basic_unique_ptr const&) = delete;
 
-  basic_unique_ptr(basic_unique_ptr&& o)
+  basic_unique_ptr(basic_unique_ptr&& o) noexcept
       : el_{o.el_}, self_allocated_{o.self_allocated_} {
     o.el_ = nullptr;
     o.self_allocated_ = false;
   }
 
-  basic_unique_ptr& operator=(basic_unique_ptr&& o) {
+  basic_unique_ptr& operator=(basic_unique_ptr&& o) noexcept {
     el_ = o.el_;
     self_allocated_ = o.self_allocated_;
     o.el_ = nullptr;


### PR DESCRIPTION
Certainly noexcept:

- [x] unique_ptr
- [x] offset_ptr

Unsure if noexcept:
- [x] hash_storage (static array initialization in empty_group() ?)

Noexcept depends on the contained elements:
~~variant~~ **not implemented in this PR**
