### PR TITLE
fix mmap move constructor + assignment for windows

### DIFF
--- a/include/cista/mmap.h
+++ b/include/cista/mmap.h
@@ -54,6 +54,9 @@ struct mmap {
         size_{o.size_},
         used_size_{o.used_size_},
         addr_{o.addr_} {
+#ifdef _MSC_VER
+    file_mapping_ = o.file_mapping_;
+#endif
     o.addr_ = nullptr;
   }
 
@@ -63,6 +66,9 @@ struct mmap {
     size_ = o.size_;
     used_size_ = o.used_size_;
     addr_ = o.addr_;
+#ifdef _MSC_VER
+    file_mapping_ = o.file_mapping_;
+#endif
     o.addr_ = nullptr;
     return *this;
   }


### PR DESCRIPTION
The `file_mapping_` handle was not moved, which results in a crash in the destructor when trying to close the invalid handle.