### PR TITLE
vector: use memcpy for trivially copyable types

### DIFF
--- a/include/cista/containers/vector.h
+++ b/include/cista/containers/vector.h
@@ -159,8 +159,10 @@ struct basic_vector {
 
   void set(basic_vector const& arr) {
     if constexpr (std::is_trivially_copyable_v<T>) {
-      reserve(arr.used_size_);
-      std::memcpy(data(), arr.data(), arr.used_size_ * sizeof(T));
+      if (arr.used_size_ != 0) {
+        reserve(arr.used_size_);
+        std::memcpy(data(), arr.data(), arr.used_size_ * sizeof(T));
+      }
       used_size_ = arr.used_size_;
     } else {
       set(std::begin(arr), std::end(arr));

--- a/include/cista/containers/vector.h
+++ b/include/cista/containers/vector.h
@@ -44,7 +44,7 @@ struct basic_vector {
     arr.allocated_size_ = 0;
   }
 
-  basic_vector(basic_vector const& arr) { set(std::begin(arr), std::end(arr)); }
+  basic_vector(basic_vector const& arr) { set(arr); }
 
   basic_vector& operator=(basic_vector&& arr) noexcept {
     deallocate();
@@ -63,7 +63,9 @@ struct basic_vector {
   }
 
   basic_vector& operator=(basic_vector const& arr) {
-    set(std::begin(arr), std::end(arr));
+    if (&arr != this) {
+      set(arr);
+    }
     return *this;
   }
 
@@ -153,6 +155,16 @@ struct basic_vector {
     }
 
     used_size_ = static_cast<TemplateSizeType>(range_size);
+  }
+
+  void set(basic_vector const& arr) {
+    if constexpr (std::is_trivially_copyable_v<T>) {
+      reserve(arr.used_size_);
+      std::memcpy(data(), arr.data(), arr.used_size_ * sizeof(T));
+      used_size_ = arr.used_size_;
+    } else {
+      set(std::begin(arr), std::end(arr));
+    }
   }
 
   friend std::ostream& operator<<(std::ostream& out, basic_vector const& v) {


### PR DESCRIPTION
This changes vector to use memcpy for trivially copyable types when copying a vector. For large vectors (several hundred MB/GB), this is ~2x faster on my machine (MSVC).