### PR TITLE
Fails to serialize when entire vector contents are erased

### DIFF
--- a/test/vector_test.cc
+++ b/test/vector_test.cc
@@ -262,3 +262,38 @@ TEST_CASE("complex_type_insert") {
   REQUIRE(u.size() == v.size());
   REQUIRE(u.size() == 2048);
 }
+
+TEST_CASE("erase then serialize") {
+  using cista::raw::vector;
+
+  std::vector<uint8_t> buf;
+  {
+    auto v = vector<int>{3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 9};
+    v.erase(std::remove_if(begin(v), end(v), [](auto&& i) { return i > 5; }),
+            end(v));
+
+    buf = cista::serialize(v);
+  }
+
+  auto deserialized = cista::deserialize<vector<int>>(buf);
+
+  CHECK(*deserialized == vector<int>{3, 1, 4, 1, 5, 2, 5, 3, 5});
+}
+
+TEST_CASE("erase until empty then serialize") {
+  using cista::raw::vector;
+
+  std::vector<uint8_t> buf;
+
+  {
+    auto v = vector<int>{3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 9};
+    v.erase(std::remove_if(begin(v), end(v), [](auto&& i) { return i != 10; }),
+            end(v));
+
+    buf = cista::serialize(v);
+  }
+
+  auto deserialized = cista::deserialize<vector<int>>(buf);
+
+  CHECK(*deserialized == vector<int>{});
+}


### PR DESCRIPTION
See the two added tests. The first one passes as expected. The second one fails. 

Might be related, but I don't think neither of the two erase functions in basic_vector ensure that https://github.com/felixguendling/cista/blob/eb1b0199eef401493db0d2dd735a14481b823083/include/cista/serialization.h#L657 or similar are satisfied.