### PR TITLE
add byte_buf to memory_holder variant

### DIFF
--- a/include/cista/memory_holder.h
+++ b/include/cista/memory_holder.h
@@ -8,6 +8,6 @@
 
 namespace cista {
 
-using memory_holder = std::variant<buf<mmap>, buffer>;
+using memory_holder = std::variant<buf<mmap>, buffer, byte_buf>;
 
 }  // namespace cista


### PR DESCRIPTION
`byte_buf` (`std::vector<uint8_t>`) is returned by `cista::serialize`.

MOTIS uses `memory_holder` to store data. Adding `byte_buf` allows easy data duplication by serializing and deserializing the data without the need to make a copy of the buffer.