### PR TITLE
Tuple fix

### DIFF
--- a/include/cista/containers/tuple.h
+++ b/include/cista/containers/tuple.h
@@ -44,7 +44,7 @@ Head& get(tuple<Head, Tail...>& t) {
 template <size_t I, typename Head, typename... Tail,
           std::enable_if_t<I != 0U, int> = 0>
 auto& get(tuple<Head, Tail...>& t) {
-  return get<I - 1U, Tail...>(t);
+  return get<I - 1U, Tail...>(static_cast<tuple<Tail...>&>(t));
 }
 
 template <size_t I, typename Head, typename... Tail,
@@ -56,7 +56,7 @@ Head const& get(tuple<Head, Tail...> const& t) {
 template <size_t I, typename Head, typename... Tail,
           std::enable_if_t<I != 0U, int> = 0>
 auto const& get(tuple<Head, Tail...> const& t) {
-  return get<I - 1U, Tail...>(t);
+  return get<I - 1U, Tail...>(static_cast<tuple<Tail...> const&>(t));
 }
 
 template <size_t I, typename Head, typename... Tail,
@@ -68,7 +68,7 @@ Head&& get(tuple<Head, Tail...>&& t) {
 template <size_t I, typename Head, typename... Tail,
           std::enable_if_t<I != 0U, int> = 0>
 auto&& get(tuple<Head, Tail...>&& t) {
-  return get<I - 1U, Tail...>(t);
+  return get<I - 1U, Tail...>(static_cast<tuple<Tail...>&&>(t));
 }
 
 template <typename T>

--- a/include/cista/containers/tuple.h
+++ b/include/cista/containers/tuple.h
@@ -93,6 +93,9 @@ struct tuple_element<0, tuple<Head, Tail...>> {
   using type = Head;
 };
 
+template <std::size_t I, typename... Ts>
+using tuple_element_t = typename tuple_element<I, Ts...>::type;
+
 template <typename F, typename Tuple, std::size_t... I>
 constexpr decltype(auto) apply_impl(std::index_sequence<I...>, F&& f,
                                     Tuple&& t) {
@@ -184,7 +187,6 @@ std::enable_if_t<is_tuple_v<decay_t<Tuple>>, bool> operator>=(Tuple&& a,
 }  // namespace cista
 
 namespace std {
-
 template <typename... Pack>
 struct tuple_size<cista::tuple<Pack...>>
     : cista::tuple_size<cista::tuple<Pack...>> {};
@@ -193,4 +195,4 @@ template <std::size_t I, typename... Pack>
 struct tuple_element<I, cista::tuple<Pack...>>
     : cista::tuple_element<I, cista::tuple<Pack...>> {};
 
-} // namespace std
+}  // namespace std

--- a/include/cista/containers/tuple.h
+++ b/include/cista/containers/tuple.h
@@ -81,6 +81,18 @@ struct tuple_size<tuple<T...>>
 template <typename T>
 inline constexpr std::size_t tuple_size_v = tuple_size<std::decay_t<T>>::value;
 
+template <std::size_t I, typename T>
+struct tuple_element;
+
+template <std::size_t I, typename Head, typename... Tail>
+struct tuple_element<I, tuple<Head, Tail...>>
+    : tuple_element<I - 1, tuple<Tail...>> {};
+
+template <typename Head, typename... Tail>
+struct tuple_element<0, tuple<Head, Tail...>> {
+  using type = Head;
+};
+
 template <typename F, typename Tuple, std::size_t... I>
 constexpr decltype(auto) apply_impl(std::index_sequence<I...>, F&& f,
                                     Tuple&& t) {
@@ -170,3 +182,13 @@ std::enable_if_t<is_tuple_v<decay_t<Tuple>>, bool> operator>=(Tuple&& a,
 }
 
 }  // namespace cista
+
+namespace std {
+
+template <typename... Pack>
+struct tuple_size<cista::tuple<Pack...>> : cista::tuple_size<cista::tuple<Pack...>> {};
+
+template <std::size_t I, typename... Pack>
+struct tuple_element<I, cista::tuple<Pack...>> : cista::tuple_element<I, cista::tuple<Pack...>> {};
+
+} // namespace std

--- a/include/cista/containers/tuple.h
+++ b/include/cista/containers/tuple.h
@@ -186,9 +186,11 @@ std::enable_if_t<is_tuple_v<decay_t<Tuple>>, bool> operator>=(Tuple&& a,
 namespace std {
 
 template <typename... Pack>
-struct tuple_size<cista::tuple<Pack...>> : cista::tuple_size<cista::tuple<Pack...>> {};
+struct tuple_size<cista::tuple<Pack...>>
+    : cista::tuple_size<cista::tuple<Pack...>> {};
 
 template <std::size_t I, typename... Pack>
-struct tuple_element<I, cista::tuple<Pack...>> : cista::tuple_element<I, cista::tuple<Pack...>> {};
+struct tuple_element<I, cista::tuple<Pack...>>
+    : cista::tuple_element<I, cista::tuple<Pack...>> {};
 
 } // namespace std

--- a/test/tuple_test.cc
+++ b/test/tuple_test.cc
@@ -21,6 +21,23 @@ TEST_CASE("tuple get") {
   CHECK(cista::get<2>(t) == '\0');
 }
 
+TEST_CASE("tuple get with same types") {
+  auto t = cista::tuple{1, 42, 1336, 11};
+
+  cista::get<2>(t) += 1;
+
+  CHECK(cista::get<0>(t) == 1);
+  CHECK(cista::get<1>(t) == 42);
+  CHECK(cista::get<2>(t) == 1337);
+  CHECK(cista::get<3>(t) == 11);
+  CHECK(cista::tuple_size_v<decltype(t)> == 4U);
+  cista::apply([](auto&... f) { ((f = {}), ...); }, t);
+  CHECK(cista::get<0>(t) == 0);
+  CHECK(cista::get<1>(t) == 0);
+  CHECK(cista::get<2>(t) == 0);
+  CHECK(cista::get<3>(t) == 0);
+}
+
 TEST_CASE("tuple comparison") {
   auto a = cista::tuple{2, 'a'};
   auto b = cista::tuple{1, 'b'};

--- a/test/tuple_test.cc
+++ b/test/tuple_test.cc
@@ -38,6 +38,16 @@ TEST_CASE("tuple get with same types") {
   CHECK(cista::get<3>(t) == 0);
 }
 
+TEST_CASE("tuple get with same type") {
+  auto t = cista::tuple{1, 42, 1336, 11};
+  auto& [t0, t1, t2, t3] = t;
+  t2 += 1;
+  CHECK(t0 == 1);
+  CHECK(t1 == 42);
+  CHECK(t2 == 1337);
+  CHECK(t3 == 11);
+}
+
 TEST_CASE("tuple comparison") {
   auto a = cista::tuple{2, 'a'};
   auto b = cista::tuple{1, 'b'};

--- a/test/tuple_test.cc
+++ b/test/tuple_test.cc
@@ -38,7 +38,7 @@ TEST_CASE("tuple get with same types") {
   CHECK(cista::get<3>(t) == 0);
 }
 
-TEST_CASE("tuple get with same type") {
+TEST_CASE("tuple2 structured bindings") {
   auto t = cista::tuple{1, 42, 1336, 11};
   auto& [t0, t1, t2, t3] = t;
   t2 += 1;


### PR DESCRIPTION
Fixes cista::get for cista::tuple with identical types. 
Enables structured bindings for cista::tuple.

Originally, I was trying to make 

`struct s {
cista::tuple<int, int, int> t_;
};`

serialize by "default". It is not in standard layout due to the tuple implementation, so to_tuple_works always evaluates to false. It should serialize just fine in practice if the static_assert is disabled :). I think there is no possibility to catch this edge case in to_tuple_works, or is there?
