### PR TITLE
WIP: implement static type hashing

### DIFF
--- a/include/cista/containers/array.h
+++ b/include/cista/containers/array.h
@@ -11,6 +11,8 @@ template <typename T, std::size_t Size>
 struct array {
   using value_type = T;
 
+  static constexpr std::size_t size() noexcept { return Size; }
+
   constexpr T const& operator[](std::size_t const index) const noexcept {
     return el_[index];
   }

--- a/include/cista/containers/array.h
+++ b/include/cista/containers/array.h
@@ -98,6 +98,15 @@ struct array {
   T el_[Size];
 };
 
+template <class T>
+struct is_cista_array: std::false_type {};
+
+template <class T, size_t Size>
+struct is_cista_array<array<T, Size>>: std::true_type {};
+
+template <class T>
+inline constexpr bool is_cista_array_v = is_cista_array<T>::value;
+
 namespace raw {
 using cista::array;
 }  // namespace raw

--- a/include/cista/containers/array.h
+++ b/include/cista/containers/array.h
@@ -9,7 +9,7 @@ namespace cista {
 
 template <typename T, std::size_t Size>
 struct array {
-  constexpr std::size_t size() const noexcept { return Size; }
+  using value_type = T;
 
   constexpr T const& operator[](std::size_t const index) const noexcept {
     return el_[index];

--- a/include/cista/type_hash/static_type_hash.h
+++ b/include/cista/type_hash/static_type_hash.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <type_traits>
+
+#include "cista/hash.h"
+#include "cista/containers.h"
+
+namespace cista {
+
+template <class T>
+inline constexpr bool dependent_false_v = false;
+
+template<class T, class = void>
+struct has_static_hash : std::false_type {};
+
+template<class T>
+struct has_static_hash<T, std::enable_if_t<std::is_invocable_r_v<hash_t, decltype(T::static_type_hash)>>>
+: std::true_type
+{};
+
+template <class T, size_t N>
+struct has_static_hash<array<T, N>>: std::true_type {};
+
+template<class T>
+constexpr bool has_static_hash_v = has_static_hash<T>::value;
+
+template <typename T>
+hash_t static_type_hash(hash_t h)
+{
+  if constexpr (std::is_arithmetic_v<T>)
+  {
+    if constexpr (std::is_integral_v<T>)
+    {
+        if constexpr (std::is_signed_v<T>)
+        return hash_combine(h, hash("unsigned integer"), sizeof(T));
+        else return hash_combine(h, hash("signed integer"), sizeof(T));
+    }
+    else return hash_combine(h, hash("floating point"), sizeof(T));
+  }
+
+  else if constexpr (is_cista_array_v<T>)
+    return static_type_hash<typename T::value_type>(hash_combine(h, hash("array"), T::size()));
+
+  else if constexpr (has_static_hash_v<T>)
+    return T::static_type_hash(h);
+
+  else static_assert(dependent_false_v<T>, "One of the classes do not implement static type hashing.");
+}
+
+template <typename T>
+hash_t static_type_hash() {
+  return static_type_hash<T>(BASE_HASH);
+}
+
+}


### PR DESCRIPTION
Starting from the issue #152 that I opened, this is an initial work towards that goal, I hope you find this as a nice addition. (this change unfortunately did not fix my issue, which is elsewhere it seems).

I implemented a second path when hashing, when the classes that are getting hashed have a static member function called `hash_t static_type_hash(hash_t h)`. Then, the same approach as before is used: the user has to manually call the same function on its members to obtain the final hash.

I have a little issue where the struct `has_static_hash` isn't working as I hoped it would. Needs investigating.

Adel.