### PR TITLE
fix optional

### DIFF
--- a/include/cista/containers/optional.h
+++ b/include/cista/containers/optional.h
@@ -25,7 +25,7 @@ struct optional {
   optional(optional&& other) noexcept { move(std::forward<optional>(other)); }
   optional& operator=(optional&& other) noexcept {
     return move(std::forward<optional>(other));
-  };
+  }
 
   optional& copy(optional const& other) {
     if (other.has_value()) {

--- a/include/cista/containers/optional.h
+++ b/include/cista/containers/optional.h
@@ -19,6 +19,34 @@ struct optional {
   template <typename... Ts>
   optional(std::nullopt_t) noexcept {}
 
+  optional(optional const& other) { copy(other); }
+  optional& operator=(optional const& other) { return copy(other); }
+
+  optional(optional&& other) noexcept { move(std::forward<optional>(other)); }
+  optional& operator=(optional&& other) noexcept {
+    return move(std::forward<optional>(other));
+  };
+
+  optional& copy(optional const& other) {
+    if (other.has_value()) {
+      new (&storage_[0]) T{other.value()};
+    }
+
+    valid_ = other.has_value();
+
+    return *this;
+  }
+
+  optional& move(optional&& other) {
+    if (other.has_value()) {
+      new (&storage_[0]) T(std::move(other.value()));
+    }
+
+    valid_ = other.has_value();
+
+    return *this;
+  }
+
   T const& value() const {
     if (!valid_) {
       throw std::bad_optional_access{};

--- a/include/cista/serialization.h
+++ b/include/cista/serialization.h
@@ -377,9 +377,9 @@ void serialize(Ctx& c, variant<T...> const* origin, offset_t const pos) {
 template <typename Ctx, typename T>
 void serialize(Ctx& c, optional<T> const* origin, offset_t const pos) {
   using Type = decay_t<decltype(*origin)>;
-  auto const offset = cista_member_offset(Type, storage_);
+
   if (origin->valid_) {
-    serialize(c, &origin->storage_[0], pos + offset);
+    serialize(c, &origin->value(), pos + cista_member_offset(Type, storage_));
   }
 }
 


### PR DESCRIPTION
fixes two bugs with cista::optional when wrapping types with non-trivial copy/move operations (e.g. offset::ptr).

1. call copy/move constructors/assignment operators explicitly for types with non-trivial copy/move operations.
2. use the serialization overload for the wrapped typed instead of the generic optional storage