### PR TITLE
remove constexpr from bitvec shift

### DIFF
--- a/include/cista/containers/bitvec.h
+++ b/include/cista/containers/bitvec.h
@@ -295,7 +295,7 @@ struct basic_bitvec {
       return *this;
     }
 
-    if constexpr (blocks_.size() == 1U) {
+    if (blocks_.size() == 1U) {
       blocks_[0] <<= shift;
       return *this;
     } else {


### PR DESCRIPTION
in bitvec the blocks_.size() is not known at compile time.