### PR TITLE
basic_unique_ptr: reset on move assignment

### DIFF
--- a/include/cista/containers/unique_ptr.h
+++ b/include/cista/containers/unique_ptr.h
@@ -28,6 +28,7 @@ struct basic_unique_ptr {
   }
 
   basic_unique_ptr& operator=(basic_unique_ptr&& o) noexcept {
+    reset();
     el_ = o.el_;
     self_allocated_ = o.self_allocated_;
     o.el_ = nullptr;


### PR DESCRIPTION
Hello!

While I was running asan and tsan tests on my project, I met a memory leak. It took me a while, but I found the culprit ! I think cista definitely needs to have its tests run with the address sanitizer.

Now that I think about it: maybe it's worth specialising `std::swap` for cista's classes.

Adel