### PR TITLE
add missing generic_string constructors

### DIFF
--- a/include/cista/containers/string.h
+++ b/include/cista/containers/string.h
@@ -36,6 +36,12 @@ struct generic_string {
   }
   generic_string(char const* s, owning_t const) { set_owning(s, mstrlen(s)); }
   generic_string(char const* s, non_owning_t const) { set_non_owning(s); }
+  generic_string(char const* s, msize_t const len, owning_t const) {
+    set_owning(s, len);
+  }
+  generic_string(char const* s, msize_t const len, non_owning_t const) {
+    set_non_owning(s, len);
+  }
 
   char* begin() noexcept { return data(); }
   char* end() noexcept { return data() + size(); }


### PR DESCRIPTION
The two added constructors are necessary for the following constructors to work:
* basic_string(char const* s, typename base::msize_t const len)
* basic_string_view(char const* s, typename base::msize_t const len)