### PR TITLE
static type hash small fixes

### DIFF
--- a/include/cista/serialization.h
+++ b/include/cista/serialization.h
@@ -644,6 +644,11 @@ void check(std::uint8_t const* const from, std::uint8_t const* const to) {
                type_hash<T>(),
            "invalid version");
   }
+  else if constexpr ((Mode & mode::WITH_STATIC_VERSION) == mode::WITH_STATIC_VERSION) {
+    verify(convert_endian<Mode>(*reinterpret_cast<hash_t const*>(from)) ==
+               static_type_hash<T>(),
+           "invalid static version");
+  }
 
   if constexpr ((Mode & mode::WITH_INTEGRITY) == mode::WITH_INTEGRITY) {
     verify(convert_endian<Mode>(*reinterpret_cast<std::uint64_t const*>(

--- a/include/cista/type_hash/static_type_hash.h
+++ b/include/cista/type_hash/static_type_hash.h
@@ -99,7 +99,7 @@ constexpr auto hash_tuple_element(hash_data<NMaxTypes> const h) noexcept {
 template <typename Tuple, std::size_t NMaxTypes, std::size_t... I>
 constexpr auto hash_tuple(Tuple const*, hash_data<NMaxTypes> h,
                           std::index_sequence<I...>) noexcept {
-  (hash_tuple_element<Tuple, NMaxTypes, I>(h), ...);
+  ((h = hash_tuple_element<Tuple, NMaxTypes, I>(h)), ...);
   return h;
 }
 


### PR DESCRIPTION
Hello!

Hope you are doing well, during some of my internal tests, I realized `cista` wasn't throwing when trying to deserialize a type `T1` as a type `T2`, which were related but not the same: one contained many elements of the second, something like
```c++
struct T1
{
   int a;
}

struct T2
{
  T1 a,b,c,d,e,f;
}
```
and I found two things to fix, so here you go!

Adel