### PR TITLE
offset_ptr: fix __cplusplus check for msvc

### DIFF
--- a/include/cista/containers/offset_ptr.h
+++ b/include/cista/containers/offset_ptr.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__has_include) && __cplusplus >= 202002L
+#if defined(__has_include) && (_MSVC_LANG >= 202002L || __cplusplus >= 202002L)
 #if __has_include(<bit>)
 #include <bit>
 #endif


### PR DESCRIPTION
Fixes compilation using MSVC 17.7 if `/Zc:__cplusplus` is not set