### PR TITLE
type_traits: Separate type traits helpers into a new header file

### DIFF
--- a/include/cista/containers/string.h
+++ b/include/cista/containers/string.h
@@ -8,6 +8,7 @@
 #include <string_view>
 
 #include "cista/containers/ptr.h"
+#include "cista/type_traits.h"
 
 namespace cista {
 
@@ -422,9 +423,6 @@ struct basic_string_view : public generic_string<Ptr> {
 };
 
 template <typename Ptr>
-struct is_string_helper : std::false_type {};
-
-template <typename Ptr>
 struct is_string_helper<generic_string<Ptr>> : std::true_type {};
 
 template <typename Ptr>
@@ -432,9 +430,6 @@ struct is_string_helper<basic_string<Ptr>> : std::true_type {};
 
 template <typename Ptr>
 struct is_string_helper<basic_string_view<Ptr>> : std::true_type {};
-
-template <class T>
-constexpr bool is_string_v = is_string_helper<std::remove_cv_t<T>>::value;
 
 namespace raw {
 using generic_string = generic_string<ptr<char const>>;

--- a/include/cista/hashing.h
+++ b/include/cista/hashing.h
@@ -15,6 +15,7 @@
 #include "cista/hash.h"
 #include "cista/is_iterable.h"
 #include "cista/reflection/for_each_field.h"
+#include "cista/type_traits.h"
 
 namespace cista {
 
@@ -49,18 +50,6 @@ struct is_hash_equivalent_helper : std::false_type {};
 template <typename A, typename B>
 constexpr bool is_hash_equivalent_v =
     is_hash_equivalent_helper<std::remove_cv_t<A>, std::remove_cv_t<B>>::value;
-
-template <typename T, typename = void>
-struct is_char_array_helper : std::false_type {};
-
-template <std::size_t N>
-struct is_char_array_helper<char const[N]> : std::true_type {};
-
-template <std::size_t N>
-struct is_char_array_helper<char[N]> : std::true_type {};
-
-template <typename T>
-constexpr bool is_char_array_v = is_char_array_helper<T>::value;
 
 template <typename T>
 constexpr bool is_string_like_v =

--- a/include/cista/type_traits.h
+++ b/include/cista/type_traits.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <type_traits>
+
+namespace cista {
+
+template <typename T, typename = void>
+struct is_char_array_helper : std::false_type {};
+
+template <std::size_t N>
+struct is_char_array_helper<char const[N]> : std::true_type {};
+
+template <std::size_t N>
+struct is_char_array_helper<char[N]> : std::true_type {};
+
+template <typename T>
+constexpr bool is_char_array_v = is_char_array_helper<T>::value;
+
+template <typename Ptr>
+struct is_string_helper : std::false_type {};
+
+template <class T>
+constexpr bool is_string_v = is_string_helper<std::remove_cv_t<T>>::value;
+
+}  // namespace cista


### PR DESCRIPTION
This commit adds cista/type_traits.h and move is_char_array_helper and is_string_helper into that new header file.