### PR TITLE
Allow the library to be used in -fno-exception targets

### DIFF
--- a/include/cista/aligned_allocator.h
+++ b/include/cista/aligned_allocator.h
@@ -4,6 +4,7 @@
 #include <stdexcept>
 
 #include "cista/aligned_alloc.h"
+#include "cista/exception.h"
 
 namespace cista {
 
@@ -34,7 +35,7 @@ struct aligned_allocator {
     auto const ptr =
         static_cast<pointer>(CISTA_ALIGNED_ALLOC(N, n * sizeof(value_type)));
     if (ptr == nullptr) {
-      throw std::bad_alloc{};
+      throw_exception(std::bad_alloc{});
     }
     return ptr;
   }

--- a/include/cista/cista_exception.h
+++ b/include/cista/cista_exception.h
@@ -2,6 +2,8 @@
 
 #include <exception>
 
+#include "cista/exception.h"
+
 namespace cista {
 
 struct cista_exception : public std::runtime_error {

--- a/include/cista/containers/cstring.h
+++ b/include/cista/containers/cstring.h
@@ -9,6 +9,7 @@
 #include <string_view>
 
 #include "cista/containers/ptr.h"
+#include "cista/exception.h"
 #include "cista/type_traits.h"
 
 namespace cista {
@@ -310,7 +311,7 @@ struct generic_cstring {
     heap(msize_t len, owning_t) {
       char* mem = static_cast<char*>(std::malloc(len + 1));
       if (mem == nullptr) {
-        throw std::bad_alloc{};
+        throw_exception(std::bad_alloc{});
       }
       mem[len] = '\0';
       ptr_ = mem;

--- a/include/cista/containers/hash_storage.h
+++ b/include/cista/containers/hash_storage.h
@@ -12,6 +12,7 @@
 #include "cista/bit_counting.h"
 #include "cista/containers/ptr.h"
 #include "cista/decay.h"
+#include "cista/exception.h"
 #include "cista/hash.h"
 
 namespace cista {
@@ -345,7 +346,7 @@ struct hash_storage {
   mapped_type& at_impl(Key&& key) {
     auto const it = find(std::forward<Key>(key));
     if (it == end()) {
-      throw std::out_of_range{"hash_storage::at() key not found"};
+      throw_exception(std::out_of_range{"hash_storage::at() key not found"});
     }
     return GetValue{}(*it);
   }
@@ -589,7 +590,7 @@ struct hash_storage {
     entries_ = reinterpret_cast<T*>(
         CISTA_ALIGNED_ALLOC(ALIGNMENT, static_cast<std::size_t>(size)));
     if (entries_ == nullptr) {
-      throw std::bad_alloc{};
+      throw_exception(std::bad_alloc{});
     }
 #if defined(CISTA_ZERO_OUT)
     std::memset(entries_, 0, size);

--- a/include/cista/containers/mutable_fws_multimap.h
+++ b/include/cista/containers/mutable_fws_multimap.h
@@ -13,6 +13,7 @@
 #include "cista/bit_counting.h"
 #include "cista/containers/array.h"
 #include "cista/containers/vector.h"
+#include "cista/exception.h"
 #include "cista/next_power_of_2.h"
 #include "cista/verify.h"
 
@@ -124,8 +125,8 @@ struct dynamic_fws_multimap_base {
 
     size_type bucket_index(const_iterator it) const {
       if (it < begin() || it >= end()) {
-        throw std::out_of_range{
-            "dynamic_fws_multimap::bucket::bucket_index() out of range"};
+        throw_exception(std::out_of_range{
+            "dynamic_fws_multimap::bucket::bucket_index() out of range"});
       }
       return std::distance(begin(), it);
     }
@@ -239,8 +240,8 @@ struct dynamic_fws_multimap_base {
     size_type get_and_check_data_index(size_type index) const {
       auto const& idx = get_index();
       if (index >= idx.size_) {
-        throw std::out_of_range{
-            "dynamic_fws_multimap::bucket::at() out of range"};
+        throw_exception(std::out_of_range{
+            "dynamic_fws_multimap::bucket::at() out of range"});
       }
       return idx.begin_ + index;
     }
@@ -397,14 +398,16 @@ struct dynamic_fws_multimap_base {
 
   mutable_bucket at(access_t const index) {
     if (index >= index_.size()) {
-      throw std::out_of_range{"dynamic_fws_multimap::at() out of range"};
+      throw_exception(
+          std::out_of_range{"dynamic_fws_multimap::at() out of range"});
     }
     return {*this, to_idx(index)};
   }
 
   const_bucket at(access_t const index) const {
     if (index >= index_.size()) {
-      throw std::out_of_range{"dynamic_fws_multimap::at() out of range"};
+      throw_exception(
+          std::out_of_range{"dynamic_fws_multimap::at() out of range"});
     }
     return {*this, to_idx(index)};
   }

--- a/include/cista/containers/optional.h
+++ b/include/cista/containers/optional.h
@@ -4,6 +4,8 @@
 #include <type_traits>
 #include <utility>
 
+#include "cista/exception.h"
+
 namespace cista {
 
 template <typename T>
@@ -49,14 +51,14 @@ struct optional {
 
   T const& value() const {
     if (!valid_) {
-      throw std::bad_optional_access{};
+      throw_exception(std::bad_optional_access{});
     }
     return *reinterpret_cast<T const*>(&storage_[0]);
   }
 
   T& value() {
     if (!valid_) {
-      throw std::bad_optional_access{};
+      throw_exception(std::bad_optional_access{});
     }
     return *reinterpret_cast<T*>(&storage_[0]);
   }

--- a/include/cista/containers/string.h
+++ b/include/cista/containers/string.h
@@ -8,6 +8,7 @@
 #include <string_view>
 
 #include "cista/containers/ptr.h"
+#include "cista/exception.h"
 #include "cista/type_traits.h"
 
 namespace cista {
@@ -89,7 +90,7 @@ struct generic_string {
     } else {
       h_.ptr_ = static_cast<char*>(std::malloc(len));
       if (h_.ptr_ == nullptr) {
-        throw std::bad_alloc{};
+        throw_exception(std::bad_alloc{});
       }
       h_.size_ = len;
       h_.self_allocated_ = true;

--- a/include/cista/containers/variant.h
+++ b/include/cista/containers/variant.h
@@ -6,6 +6,7 @@
 #include <limits>
 #include <type_traits>
 
+#include "cista/exception.h"
 #include "cista/hashing.h"
 
 namespace cista {
@@ -218,7 +219,7 @@ struct variant {
   template <typename F>
   auto apply(F&& f) -> decltype(f(std::declval<type_at_index_t<0U, T...>>())) {
     if (idx_ == NO_VALUE) {
-      throw std::runtime_error{"variant::apply: no value"};
+      throw_exception(std::runtime_error{"variant::apply: no value"});
     }
     return apply(std::forward<F>(f), idx_, *this);
   }
@@ -227,7 +228,7 @@ struct variant {
   auto apply(F&& f) const
       -> decltype(f(std::declval<type_at_index_t<0U, T...>>())) {
     if (idx_ == NO_VALUE) {
-      throw std::runtime_error{"variant::apply: no value"};
+      throw_exception(std::runtime_error{"variant::apply: no value"});
     }
     return apply(std::forward<F>(f), idx_, *this);
   }

--- a/include/cista/containers/vector.h
+++ b/include/cista/containers/vector.h
@@ -12,6 +12,7 @@
 
 #include "cista/allocator.h"
 #include "cista/containers/ptr.h"
+#include "cista/exception.h"
 #include "cista/is_iterable.h"
 #include "cista/next_power_of_2.h"
 #include "cista/strong.h"
@@ -143,7 +144,7 @@ struct basic_vector {
 
   T& at(access_type const index) {
     if (index >= used_size_) {
-      throw std::out_of_range{"vector::at(): invalid index"};
+      throw_exception(std::out_of_range{"vector::at(): invalid index"});
     }
     return (*this)[index];
   }
@@ -316,7 +317,7 @@ struct basic_vector {
     auto num_bytes = static_cast<std::size_t>(next_size) * sizeof(T);
     auto mem_buf = static_cast<T*>(std::malloc(num_bytes));  // NOLINT
     if (mem_buf == nullptr) {
-      throw std::bad_alloc();
+      throw_exception(std::bad_alloc());
     }
 
     if (size() != 0) {

--- a/include/cista/exception.h
+++ b/include/cista/exception.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace cista {
+
+template <typename E>
+void throw_exception(E&& e) {
+#if !defined(__cpp_exceptions) || __cpp_exceptions < 199711L
+  abort();
+#else
+  throw e;
+#endif
+}
+
+}  // namespace cista

--- a/include/cista/serialization.h
+++ b/include/cista/serialization.h
@@ -547,7 +547,7 @@ Arg checked_addition(Arg a1, Args... aN) {
     }
     if (((x < 0) && (a1 < std::numeric_limits<Type>::min() - x)) ||
         ((x > 0) && (a1 > std::numeric_limits<Type>::max() - x))) {
-      throw std::overflow_error("addition overflow");
+      throw_exception(std::overflow_error("addition overflow"));
     }
     a1 = a1 + x;
   };
@@ -560,7 +560,7 @@ Arg checked_multiplication(Arg a1, Args... aN) {
   using Type = decay_t<Arg>;
   auto multiply_if_ok = [&](auto x) {
     if (a1 != 0 && ((std::numeric_limits<Type>::max() / a1) < x)) {
-      throw std::overflow_error("addition overflow");
+      throw_exception(std::overflow_error("addition overflow"));
     }
     a1 = a1 * x;
   };

--- a/include/cista/targets/file.h
+++ b/include/cista/targets/file.h
@@ -62,9 +62,9 @@ inline HANDLE open_file(char const* path, char const* mode) {
   auto const f = CreateFileA(path, access, FILE_SHARE_READ, nullptr,
                              create_mode, FILE_ATTRIBUTE_NORMAL, nullptr);
   if (f == INVALID_HANDLE_VALUE) {
-    throw std::runtime_error{std::string{"cannot open path="} + path +
-                             ", mode=" + mode + ", message=\"" +
-                             last_error_str() + "\""};
+    throw_exception(std::runtime_error{std::string{"cannot open path="} + path +
+                                       ", mode=" + mode + ", message=\"" +
+                                       last_error_str() + "\""});
   }
   return f;
 }

--- a/include/cista/verify.h
+++ b/include/cista/verify.h
@@ -3,12 +3,13 @@
 #include <stdexcept>
 
 #include "cista/cista_exception.h"
+#include "cista/exception.h"
 
 namespace cista {
 
 inline void verify(bool const condition, char const* msg) {
   if (!condition) {
-    throw cista_exception{msg};
+    throw_exception(cista_exception{msg});
   }
 }
 


### PR DESCRIPTION
This change introduces cista::throw_exception as a helper to dispatch the call to either a throw expression, or abort() call in case -fno-exception is enabled.