### PR TITLE
hash_storage: fix assignment operator

### DIFF
--- a/include/cista/containers/hash_storage.h
+++ b/include/cista/containers/hash_storage.h
@@ -292,8 +292,8 @@ struct hash_storage {
   }
 
   hash_storage& operator=(hash_storage const& other) {
+    clear();
     if (other.size() == 0U) {
-      clear();
       return *this;
     }
     for (const auto& v : other) {


### PR DESCRIPTION
The assignment operator of hash_storage now calls the `clear` function to ensure proper behavior. Previously, it only cleared the destination hash_storage if the source hash_storage was empty, leading to keys being left in the destination hash_storage that did not exist in the source, and not being copied if they already exist in the destination hash_storage. Now, the assignment operator clears the destination hash_storage every time, preventing this issue.