### PR TITLE
hash_storage: compare values in equality operator

### DIFF
--- a/include/cista/containers/hash_storage.h
+++ b/include/cista/containers/hash_storage.h
@@ -654,7 +654,8 @@ struct hash_storage {
       return false;
     }
     for (auto const& el : *this) {
-      if (b.find(GetKey()(el)) == b.end()) {
+      auto const it = b.find(GetKey()(el));
+      if (it == b.end() || GetValue()(el) != GetValue()(*it)) {
         return false;
       }
     }


### PR DESCRIPTION
Resolves #214

The equality operator for hash maps should compare both keys and mapped values, not just the keys.