### PR TITLE
cista::optional: add bool conversion operator

### DIFF
--- a/include/cista/containers/optional.h
+++ b/include/cista/containers/optional.h
@@ -64,6 +64,7 @@ struct optional {
   }
 
   bool has_value() const noexcept { return valid_; }
+  operator bool() const noexcept { return valid_; }
 
   T* operator->() noexcept { return reinterpret_cast<T*>(&storage_[0]); }
   T const* operator->() const noexcept {


### PR DESCRIPTION
Besides calling has_value() to check if the container contains anything, if (opt) pattern can be used as well.