### PR TITLE
bitvec fixes

### DIFF
--- a/include/cista/containers/bitvec.h
+++ b/include/cista/containers/bitvec.h
@@ -26,7 +26,7 @@ struct basic_bitvec {
       static_cast<size_type>(sizeof(block_t) * 8);
 
   constexpr basic_bitvec() noexcept {}
-  constexpr basic_bitvec(std::string_view s) noexcept { set(s); }
+  basic_bitvec(std::string_view s) noexcept { set(s); }
   constexpr basic_bitvec(Vec&& v) noexcept
       : size_{v.size() * bits_per_block},  // inaccurate for loading mmap vector
         blocks_{std::move(v)} {}
@@ -59,7 +59,7 @@ struct basic_bitvec {
     size_ = new_size;
   }
 
-  constexpr void set(std::string_view s) noexcept {
+  void set(std::string_view s) noexcept {
     assert(std::all_of(begin(s), end(s),
                        [](char const c) { return c == '0' || c == '1'; }));
     resize(s.size());

--- a/include/cista/containers/bitvec.h
+++ b/include/cista/containers/bitvec.h
@@ -85,6 +85,9 @@ struct basic_bitvec {
   bool operator[](Key const i) const noexcept { return test(i); }
 
   std::size_t count() const noexcept {
+    if (empty()) {
+      return 0;
+    }
     auto sum = std::size_t{0U};
     for (auto i = size_type{0U}; i != blocks_.size() - 1; ++i) {
       sum += popcount(blocks_[i]);

--- a/include/cista/containers/bitvec.h
+++ b/include/cista/containers/bitvec.h
@@ -63,7 +63,8 @@ struct basic_bitvec {
     assert(std::all_of(begin(s), end(s),
                        [](char const c) { return c == '0' || c == '1'; }));
     resize(s.size());
-    for (auto i = std::size_t{0U}; i != std::min(size_, s.size()); ++i) {
+    for (auto i = std::size_t{0U};
+         i != std::min(static_cast<std::size_t>(size_), s.size()); ++i) {
       set(i, s[s.size() - i - 1] != '0');
     }
   }


### PR DESCRIPTION
- Fix a crash in `count()` if the bitvec is empty (invalid memory access in `sanitized_last_block()`)
- Fix compilation error in `set(std::string_view)` if `size_type != std::size_t`
- Remove constexpr from `set(std::string_view)` and `basic_bitvec(std::string_view)` because the used `resize` function isn't constexpr