### PR TITLE
Update workflow and fix endian conversion and alignment in cista::generic_string

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -137,7 +137,7 @@ jobs:
       # ==== DISTRIBUTION ====
       - name: Upload Distribution
         if: matrix.config.mode == 'Release' && matrix.config.cc == 'gcc-12'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: cista.h
           path: build/cista.h

--- a/include/cista/containers/string.h
+++ b/include/cista/containers/string.h
@@ -432,7 +432,10 @@ struct generic_string {
   };
 
   struct stack {
-    bool is_short_{true};
+    union {
+      bool is_short_{true};
+      CharT __fill__;
+    };
     CharT s_[short_length_limit]{0};
   };
 

--- a/include/cista/serialization.h
+++ b/include/cista/serialization.h
@@ -226,13 +226,13 @@ void serialize(Ctx& c,
 template <typename Ctx, typename Ptr>
 void serialize(Ctx& c, generic_string<Ptr> const* origin, offset_t const pos) {
   using Type = generic_string<Ptr>;
-  auto str_convert_endian = [](Ctx& c, offset_t const pos,
+  auto str_convert_endian = [](Ctx& ctx, offset_t const start,
                                typename Type::CharT const* str,
                                offset_t const size) -> void {
     if constexpr (sizeof(typename Type::CharT) > 1) {
       for (offset_t i = 0; i < size; ++i) {
-        c.write(pos + i * sizeof(typename Type::CharT),
-                convert_endian<Ctx::MODE>(str[i]));
+        ctx.write(start + i * sizeof(typename Type::CharT),
+                  convert_endian<Ctx::MODE>(str[i]));
       }
     }
   };
@@ -840,11 +840,11 @@ void recurse(Ctx&, basic_vector<T, Ptr, Indexed, TemplateSizeType>* el,
 template <typename Ctx, typename Ptr>
 void convert_endian_and_ptr(Ctx const& c, generic_string<Ptr>* el) {
   using Type = generic_string<Ptr>;
-  auto str_convert_endian = [](Ctx const& c, typename Type::CharT* str,
+  auto str_convert_endian = [](Ctx const& ctx, typename Type::CharT* str,
                                offset_t const size) -> void {
     if constexpr (sizeof(typename Type::CharT) > 1) {
       for (offset_t i = 0; i < size; ++i) {
-        c.convert_endian(str[i]);
+        ctx.convert_endian(str[i]);
       }
     }
   };

--- a/include/cista/serialization.h
+++ b/include/cista/serialization.h
@@ -861,7 +861,7 @@ void check_state(Ctx const& c, generic_string<Ptr>* el) {
 }
 
 template <typename Ctx, typename Ptr, typename Fn>
-void recurse(Ctx& c, generic_string<Ptr>* el, Fn&& fn) {
+void recurse(Ctx&, generic_string<Ptr>* el, Fn&& fn) {
   using Type = generic_string<Ptr>;
   if constexpr (sizeof(typename Type::CharT) > 1) {
     typename Type::CharT* s = el->data();

--- a/include/cista/serialization.h
+++ b/include/cista/serialization.h
@@ -226,12 +226,12 @@ void serialize(Ctx& c,
 template <typename Ctx, typename Ptr>
 void serialize(Ctx& c, generic_string<Ptr> const* origin, offset_t const pos) {
   using Type = generic_string<Ptr>;
-  auto str_convert_endian = [](Ctx& ctx, std::size_t const start,
+  auto str_convert_endian = [](Ctx& ctx, offset_t const start,
                                typename Type::CharT const* str,
-                               std::size_t const size) -> void {
+                               offset_t const size) -> void {
     if constexpr (sizeof(typename Type::CharT) > 1) {
-      for (std::size_t i = 0; i < size; ++i) {
-        ctx.write(start + i * sizeof(typename Type::CharT),
+      for (offset_t i = 0; i < size; ++i) {
+        ctx.write(start + i * static_cast<offset_t>(sizeof(typename Type::CharT)),
                   convert_endian<Ctx::MODE>(str[i]));
       }
     }
@@ -239,8 +239,8 @@ void serialize(Ctx& c, generic_string<Ptr> const* origin, offset_t const pos) {
 
   if (origin->is_short()) {
     str_convert_endian(
-        c, static_cast<std::size_t>(pos + cista_member_offset(Type, s_.s_)),
-        origin->s_.s_, static_cast<std::size_t>(Type::short_length_limit));
+        c, pos + cista_member_offset(Type, s_.s_),
+        origin->s_.s_, static_cast<offset_t>(Type::short_length_limit));
     return;
   }
 
@@ -843,9 +843,9 @@ template <typename Ctx, typename Ptr>
 void convert_endian_and_ptr(Ctx const& c, generic_string<Ptr>* el) {
   using Type = generic_string<Ptr>;
   auto str_convert_endian = [](Ctx const& ctx, typename Type::CharT* str,
-                               offset_t const size) -> void {
+                               std::size_t const size) -> void {
     if constexpr (sizeof(typename Type::CharT) > 1) {
-      for (offset_t i = 0; i < size; ++i) {
+      for (std::size_t i = 0; i < size; ++i) {
         ctx.convert_endian(str[i]);
       }
     }
@@ -859,11 +859,11 @@ void convert_endian_and_ptr(Ctx const& c, generic_string<Ptr>* el) {
         c.check_ptr(el->h_.ptr_,
                     el->h_.size_ * sizeof(typename generic_string<Ptr>::CharT));
       }
-      str_convert_endian(c, el->data(), el->h_.size_);
+      str_convert_endian(c, el->data(), static_cast<std::size_t>(el->h_.size_));
     } catch (...) {
     }
   } else {
-    str_convert_endian(c, el->s_.s_, Type::short_length_limit);
+    str_convert_endian(c, el->s_.s_, static_cast<std::size_t>(Type::short_length_limit));
   }
 }
 

--- a/include/cista/serialization.h
+++ b/include/cista/serialization.h
@@ -231,16 +231,16 @@ void serialize(Ctx& c, generic_string<Ptr> const* origin, offset_t const pos) {
                                offset_t const size) -> void {
     if constexpr (sizeof(typename Type::CharT) > 1) {
       for (offset_t i = 0; i < size; ++i) {
-        ctx.write(start + i * static_cast<offset_t>(sizeof(typename Type::CharT)),
-                  convert_endian<Ctx::MODE>(str[i]));
+        ctx.write(
+            start + i * static_cast<offset_t>(sizeof(typename Type::CharT)),
+            convert_endian<Ctx::MODE>(str[i]));
       }
     }
   };
 
   if (origin->is_short()) {
-    str_convert_endian(
-        c, pos + cista_member_offset(Type, s_.s_),
-        origin->s_.s_, static_cast<offset_t>(Type::short_length_limit));
+    str_convert_endian(c, pos + cista_member_offset(Type, s_.s_), origin->s_.s_,
+                       static_cast<offset_t>(Type::short_length_limit));
     return;
   }
 
@@ -863,7 +863,8 @@ void convert_endian_and_ptr(Ctx const& c, generic_string<Ptr>* el) {
     } catch (...) {
     }
   } else {
-    str_convert_endian(c, el->s_.s_, static_cast<std::size_t>(Type::short_length_limit));
+    str_convert_endian(c, el->s_.s_,
+                       static_cast<std::size_t>(Type::short_length_limit));
   }
 }
 

--- a/include/cista/serialization.h
+++ b/include/cista/serialization.h
@@ -226,11 +226,11 @@ void serialize(Ctx& c,
 template <typename Ctx, typename Ptr>
 void serialize(Ctx& c, generic_string<Ptr> const* origin, offset_t const pos) {
   using Type = generic_string<Ptr>;
-  auto str_convert_endian = [](Ctx& ctx, offset_t const start,
+  auto str_convert_endian = [](Ctx& ctx, std::size_t const start,
                                typename Type::CharT const* str,
-                               offset_t const size) -> void {
+                               std::size_t const size) -> void {
     if constexpr (sizeof(typename Type::CharT) > 1) {
-      for (offset_t i = 0; i < size; ++i) {
+      for (std::size_t i = 0; i < size; ++i) {
         ctx.write(start + i * sizeof(typename Type::CharT),
                   convert_endian<Ctx::MODE>(str[i]));
       }
@@ -238,8 +238,9 @@ void serialize(Ctx& c, generic_string<Ptr> const* origin, offset_t const pos) {
   };
 
   if (origin->is_short()) {
-    str_convert_endian(c, pos + cista_member_offset(Type, s_.s_), origin->s_.s_,
-                       Type::short_length_limit);
+    str_convert_endian(
+        c, static_cast<std::size_t>(pos + cista_member_offset(Type, s_.s_)),
+        origin->s_.s_, static_cast<std::size_t>(Type::short_length_limit));
     return;
   }
 
@@ -249,7 +250,8 @@ void serialize(Ctx& c, generic_string<Ptr> const* origin, offset_t const pos) {
           : c.write(origin->data(),
                     origin->size() * sizeof(typename Type::CharT));
   if (start != NULLPTR_OFFSET) {
-    str_convert_endian(c, start, origin->data(), origin->size());
+    str_convert_endian(c, static_cast<std::size_t>(start), origin->data(),
+                       static_cast<std::size_t>(origin->size()));
   }
   c.write(pos + cista_member_offset(Type, h_.ptr_),
           convert_endian<Ctx::MODE>(

--- a/include/cista/serialization.h
+++ b/include/cista/serialization.h
@@ -250,8 +250,8 @@ void serialize(Ctx& c, generic_string<Ptr> const* origin, offset_t const pos) {
           : c.write(origin->data(),
                     origin->size() * sizeof(typename Type::CharT));
   if (start != NULLPTR_OFFSET) {
-    str_convert_endian(c, static_cast<std::size_t>(start), origin->data(),
-                       static_cast<std::size_t>(origin->size()));
+    str_convert_endian(c, start, origin->data(),
+                       static_cast<offset_t>(origin->size()));
   }
   c.write(pos + cista_member_offset(Type, h_.ptr_),
           convert_endian<Ctx::MODE>(

--- a/test/cstring_serialize_test.cc
+++ b/test/cstring_serialize_test.cc
@@ -72,6 +72,50 @@ TEST_CASE("u16string serialization with additional checks") {
   CHECK(*serialized_l == U16STR_LONG_CORNER_CASE);
 }
 
+TEST_CASE("u16string serialization endian short") {
+  cista::byte_buf str_le = {0x30, 0x00, 0x31, 0x00, 0x32, 0x00, 0x33,
+                            0x00, 0x34, 0x00, 0x35, 0x00, 0x36, 0x00};
+  cista::byte_buf str_be = {0x00, 0x30, 0x00, 0x31, 0x00, 0x32, 0x00,
+                            0x33, 0x00, 0x34, 0x00, 0x35, 0x00, 0x36};
+  u16string s = U16STR_SHORT_CORNER_CASE;
+
+  cista::byte_buf buf_le = cista::serialize(s);
+  cista::byte_buf buf_be =
+      cista::serialize<cista::mode::SERIALIZE_BIG_ENDIAN>(s);
+
+  CHECK(std::equal(buf_le.begin() + offsetof(u16string, s_.s_), buf_le.end(),
+                   str_le.begin()));
+  CHECK(std::equal(buf_be.begin() + offsetof(u16string, s_.s_), buf_be.end(),
+                   str_be.begin()));
+
+  auto const serialized_be =
+      cista::deserialize<u16string, cista::mode::SERIALIZE_BIG_ENDIAN>(buf_be);
+
+  CHECK(*serialized_be == U16STR_SHORT_CORNER_CASE);
+}
+
+TEST_CASE("u16string serialization endian long") {
+  cista::byte_buf str_le = {0x30, 0x00, 0x31, 0x00, 0x32, 0x00, 0x33, 0x00,
+                            0x34, 0x00, 0x35, 0x00, 0x36, 0x00, 0x37, 0x00};
+  cista::byte_buf str_be = {0x00, 0x30, 0x00, 0x31, 0x00, 0x32, 0x00, 0x33,
+                            0x00, 0x34, 0x00, 0x35, 0x00, 0x36, 0x00, 0x37};
+  u16string s = U16STR_LONG_CORNER_CASE;
+
+  cista::byte_buf buf_le = cista::serialize(s);
+  cista::byte_buf buf_be =
+      cista::serialize<cista::mode::SERIALIZE_BIG_ENDIAN>(s);
+
+  CHECK(std::equal(buf_le.begin() + sizeof(u16string), buf_le.end(),
+                   str_le.begin()));
+  CHECK(std::equal(buf_be.begin() + sizeof(u16string), buf_be.end(),
+                   str_be.begin()));
+
+  auto const serialized_be =
+      cista::deserialize<u16string, cista::mode::SERIALIZE_BIG_ENDIAN>(buf_be);
+
+  CHECK(*serialized_be == U16STR_LONG_CORNER_CASE);
+}
+
 using cista::raw::u32string;
 using cista::raw::u32string_view;
 
@@ -114,4 +158,48 @@ TEST_CASE("u32string serialization with additional checks") {
   CHECK(*serialized_s == U32STR_SHORT_CORNER_CASE);
   CHECK_NOTHROW(serialized_l = cista::deserialize<u32string, mode>(buf_l));
   CHECK(*serialized_l == U32STR_LONG_CORNER_CASE);
+}
+
+TEST_CASE("u32string serialization endian short") {
+  cista::byte_buf str_le = {0x30, 0x00, 0x00, 0x00, 0x31, 0x00,
+                            0x00, 0x00, 0x32, 0x00, 0x00, 0x00};
+  cista::byte_buf str_be = {0x00, 0x00, 0x00, 0x30, 0x00, 0x00,
+                            0x00, 0x31, 0x00, 0x00, 0x00, 0x32};
+  u32string s = U32STR_SHORT_CORNER_CASE;
+
+  cista::byte_buf buf_le = cista::serialize(s);
+  cista::byte_buf buf_be =
+      cista::serialize<cista::mode::SERIALIZE_BIG_ENDIAN>(s);
+
+  CHECK(std::equal(buf_le.begin() + offsetof(u32string, s_.s_), buf_le.end(),
+                   str_le.begin()));
+  CHECK(std::equal(buf_be.begin() + offsetof(u32string, s_.s_), buf_be.end(),
+                   str_be.begin()));
+
+  auto const serialized_be =
+      cista::deserialize<u32string, cista::mode::SERIALIZE_BIG_ENDIAN>(buf_be);
+
+  CHECK(*serialized_be == U32STR_SHORT_CORNER_CASE);
+}
+
+TEST_CASE("u32string serialization endian long") {
+  cista::byte_buf str_le = {0x30, 0x00, 0x00, 0x00, 0x31, 0x00, 0x00, 0x00,
+                            0x32, 0x00, 0x00, 0x00, 0x33, 0x00, 0x00, 0x00};
+  cista::byte_buf str_be = {0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0x31,
+                            0x00, 0x00, 0x00, 0x32, 0x00, 0x00, 0x00, 0x33};
+  u32string s = U32STR_LONG_CORNER_CASE;
+
+  cista::byte_buf buf_le = cista::serialize(s);
+  cista::byte_buf buf_be =
+      cista::serialize<cista::mode::SERIALIZE_BIG_ENDIAN>(s);
+
+  CHECK(std::equal(buf_le.begin() + sizeof(u32string), buf_le.end(),
+                   str_le.begin()));
+  CHECK(std::equal(buf_be.begin() + sizeof(u32string), buf_be.end(),
+                   str_be.begin()));
+
+  auto const serialized_be =
+      cista::deserialize<u32string, cista::mode::SERIALIZE_BIG_ENDIAN>(buf_be);
+
+  CHECK(*serialized_be == U32STR_LONG_CORNER_CASE);
 }


### PR DESCRIPTION
# Workflows
- Linux: update deprecated upload-artifact version to prevent automatic build failure
# cista::generic_string
- fix missing endian conversion during (de-)serialization
- ensure short string alignment