### PR TITLE
Add method to enlarge basic_vecvec::bucket

### DIFF
--- a/include/cista/containers/vector.h
+++ b/include/cista/containers/vector.h
@@ -217,13 +217,13 @@ struct basic_vector {
     return std::rotate(begin() + old_offset, begin() + old_size, end());
   }
 
-  template <typename El, typename Size = std::size_t>
-  constexpr T* insert(T* it, Size const count, El const& value) {
+  template <typename El>
+  constexpr T* insert(T* it, size_type const count, El const& value) {
     auto const old_offset = std::distance(begin(), it);
     auto const old_size = used_size_;
 
     reserve(used_size_ + count);
-    for (auto i = Size{0U}; i < count; ++i) {
+    for (auto i = size_type{0U}; i < count; ++i) {
       new (el_ + used_size_) T{value};
       ++used_size_;
     }

--- a/include/cista/containers/vector.h
+++ b/include/cista/containers/vector.h
@@ -217,6 +217,20 @@ struct basic_vector {
     return std::rotate(begin() + old_offset, begin() + old_size, end());
   }
 
+  template <typename El, typename Size = std::size_t>
+  constexpr T* insert(T* it, Size const count, El const& value) {
+    auto const old_offset = std::distance(begin(), it);
+    auto const old_size = used_size_;
+
+    reserve(used_size_ + count);
+    for (auto i = Size{0U}; i < count; ++i) {
+      new (el_ + used_size_) T{value};
+      ++used_size_;
+    }
+
+    return std::rotate(begin() + old_offset, begin() + old_size, end());
+  }
+
   template <class InputIt>
   T* insert(T* pos, InputIt first, InputIt last, std::input_iterator_tag) {
     auto const old_offset = std::distance(begin(), pos);

--- a/include/cista/containers/vecvec.h
+++ b/include/cista/containers/vecvec.h
@@ -70,13 +70,12 @@ struct basic_vecvec {
       }
     }
 
-    void grow(std::size_t const n, value_type const fill = value_type{}) {
+    void grow(std::size_t const n, value_type const& value = value_type{}) {
       verify(n >= size(), "bucket::grow: new size < old size");
       auto const growth = n - size();
-      auto const elements = std::vector(growth, fill);
 
       map_->data_.insert(std::next(std::begin(map_->data_), bucket_end_idx()),
-                         elements.begin(), elements.end());
+                         growth, value);
       for (auto i = i_ + 1; i != map_->bucket_starts_.size(); ++i) {
         map_->bucket_starts_[i] += growth;
       }

--- a/include/cista/containers/vecvec.h
+++ b/include/cista/containers/vecvec.h
@@ -74,8 +74,10 @@ struct basic_vecvec {
       verify(n >= size(), "bucket::grow: new size < old size");
       auto const growth = n - size();
 
-      map_->data_.insert(std::next(std::begin(map_->data_), bucket_end_idx()),
-                         growth, value);
+      map_->data_.insert(
+          std::next(std::begin(map_->data_), bucket_end_idx()),
+          static_cast<typename decltype(map_->data_)::size_type>(growth),
+          value);
       for (auto i = i_ + 1; i != map_->bucket_starts_.size(); ++i) {
         map_->bucket_starts_[i] += growth;
       }

--- a/include/cista/containers/vecvec.h
+++ b/include/cista/containers/vecvec.h
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <iterator>
 #include <type_traits>
+#include <vector>
 
 #include "cista/containers/vector.h"
 #include "cista/verify.h"
@@ -66,6 +67,18 @@ struct basic_vecvec {
                          std::forward<Args>(args));
       for (auto i = i_ + 1; i != map_->bucket_starts_.size(); ++i) {
         ++map_->bucket_starts_[i];
+      }
+    }
+
+    void grow(std::size_t const n, value_type const fill = value_type{}) {
+      verify(n >= size(), "bucket::grow: new size < old size");
+      auto const growth = n - size();
+      auto const elements = std::vector(growth, fill);
+
+      map_->data_.insert(std::next(std::begin(map_->data_), bucket_end_idx()),
+                         elements.begin(), elements.end());
+      for (auto i = i_ + 1; i != map_->bucket_starts_.size(); ++i) {
+        map_->bucket_starts_[i] += growth;
       }
     }
 

--- a/test/vecvec_test.cc
+++ b/test/vecvec_test.cc
@@ -1,6 +1,7 @@
 #include <array>
 #include <memory>
 #include <set>
+#include <stdexcept>
 
 #include "doctest.h"
 
@@ -75,6 +76,30 @@ TEST_CASE("vecvec bucket emplace_back test") {
   CHECK_EQ("hellox", d[key{0}].view());
   CHECK_EQ("worldx", d[key{1}].view());
   CHECK_EQ("testx", d[key{2}].view());
+}
+
+TEST_CASE("vecvec bucket grow test") {
+  using key = cista::strong<unsigned, struct x_>;
+  using data = cista::raw::vecvec<key, char>;
+  using std::literals::operator""sv;
+
+  data d;
+  d.emplace_back("hello");
+  d.emplace_back("world");
+
+  {
+    d[key{0}].grow(10);
+
+    CHECK_EQ("hello\0\0\0\0\0"sv, d[key{0}].view());
+    CHECK_EQ("world", d[key{1}].view());
+  }
+  {
+    d[key{0}].grow(13, ' ');
+
+    CHECK_EQ("hello\0\0\0\0\0   "sv, d[key{0}].view());
+    CHECK_EQ("world", d[key{1}].view());
+  }
+  { CHECK_THROWS_AS(d[key{0}].grow(5), std::runtime_error); }
 }
 
 TEST_CASE("vecvec resize test") {


### PR DESCRIPTION
Offers a method to enlarge a `basic_vecvec::bucket`, which is needed in some use cases.
Currently this is only possible by multiple calls to `bucket::push_back()`, which isn't great when inserting many elements.