### PR TITLE
file: fix windows error messages

### DIFF
--- a/include/cista/targets/file.h
+++ b/include/cista/targets/file.h
@@ -10,6 +10,7 @@
 #include <io.h>
 #include <windows.h>
 #include <string>
+#include <system_error>
 #endif
 
 #include <cinttypes>
@@ -27,27 +28,7 @@
 namespace cista {
 
 inline std::string last_error_str() {
-  auto const err = ::GetLastError();
-  if (err == 0) {
-    return "no error";
-  }
-
-  struct buf {
-    ~buf() {
-      if (b_ != nullptr) {
-        LocalFree(b_);
-        b_ = nullptr;
-      }
-    }
-    LPSTR b_ = nullptr;
-  } b;
-  auto const size = FormatMessageA(
-      FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
-          FORMAT_MESSAGE_IGNORE_INSERTS,
-      nullptr, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), b.b_, 0,
-      nullptr);
-
-  return size == 0 ? std::to_string(err) : std::string{b.b_, size};
+  return std::system_category().message(static_cast<int>(::GetLastError()));
 }
 
 inline HANDLE open_file(char const* path, char const* mode) {


### PR DESCRIPTION
Error messages when trying to open files previously always returned the numeric error code.

The existing code could be fixed by passing `reinterpret_cast<LPSTR>(&b.b_)` instead of `b.b_`, but using `std::system_category()` seems easier and also removes the trailing newline from the error message.