### PR TITLE
bitvec: add one_out()

### DIFF
--- a/include/cista/containers/bitvec.h
+++ b/include/cista/containers/bitvec.h
@@ -53,6 +53,12 @@ struct basic_bitvec {
     }
   }
 
+  void one_out() {
+    for (auto& b : blocks_) {
+      b = ~block_t{0};
+    }
+  }
+
   void resize(size_type const new_size) {
     if (new_size == size_) {
       return;


### PR DESCRIPTION
Adds a new `one_out()` function to `bitvec` that sets all bits to one (similar to the already existing `zero_out`).