### PR TITLE
Add c_str method to string to match std::string

### DIFF
--- a/include/cista/containers/cstring.h
+++ b/include/cista/containers/cstring.h
@@ -297,6 +297,8 @@ struct generic_cstring {
   char* data() noexcept { return const_cast<char*>(internal_data()); }
   char const* data() const noexcept { return internal_data(); }
 
+  char const* c_str() const noexcept { return data(); }
+
   msize_t size() const noexcept { return is_short() ? s_.size() : h_.size(); }
 
   struct heap {


### PR DESCRIPTION
For reference: https://cplusplus.com/reference/string/string/c_str/

Just a convenience method, but it's one I used in the std lib and it was a hassle to remove every call to it when I switched to Cista strings.