### PR TITLE
add push_back(T&&) overload and no-op shrink_to_fit in basic_vector

### DIFF
--- a/include/cista/containers/vector.h
+++ b/include/cista/containers/vector.h
@@ -297,6 +297,12 @@ struct basic_vector {
     ++used_size_;
   }
 
+  void push_back(T&& el) {
+    reserve(used_size_ + 1U);
+    new (el_ + used_size_) T(std::move(el));
+    ++used_size_;
+  }
+
   template <typename... Args>
   T& emplace_back(Args&&... el) {
     reserve(used_size_ + 1U);
@@ -321,6 +327,8 @@ struct basic_vector {
     }
     used_size_ = size;
   }
+
+  void shrink_to_fit() {}
 
   void pop_back() noexcept(noexcept(std::declval<T>().~T())) {
     --used_size_;


### PR DESCRIPTION
Hi,

this tiny PR would bring cista::basic_vector a little closer to the `std::vector` interface by adding

- a missing r-value accepting [push_back(T&&)](https://en.cppreference.com/w/cpp/container/vector/push_back) overload
- a no-op [shrink_to_fit](https://en.cppreference.com/w/cpp/container/vector/shrink_to_fit)

Particularly, the shrink-to-fit function being a no-op is explicitly allowed by the standard as an implementation choice for std::vector. 

The lack of these two functions has posed a problem to me when using cista with some 3rd-party libraries. Let me know if you want something changed!
