### PR TITLE
Fix: Prevent file content loss when using r+ mode on Windows

### DIFF
--- a/include/cista/targets/file.h
+++ b/include/cista/targets/file.h
@@ -39,7 +39,7 @@ inline HANDLE open_file(char const* path, char const* mode) {
   verify(read || write, "open file mode not supported");
 
   DWORD access = read ? GENERIC_READ : GENERIC_READ | GENERIC_WRITE;
-  DWORD create_mode = modify ? OPEN_ALWAYS : read ? OPEN_EXISTING : CREATE_ALWAYS;
+  DWORD create_mode = (read || modify) ? OPEN_EXISTING : CREATE_ALWAYS;
 
   auto const f = CreateFileA(path, access, FILE_SHARE_READ, nullptr,
                              create_mode, FILE_ATTRIBUTE_NORMAL, nullptr);

--- a/include/cista/targets/file.h
+++ b/include/cista/targets/file.h
@@ -32,13 +32,14 @@ inline std::string last_error_str() {
 }
 
 inline HANDLE open_file(char const* path, char const* mode) {
+  bool modify = std::strcmp(mode, "r+") == 0;
   bool read = std::strcmp(mode, "r") == 0;
-  bool write = std::strcmp(mode, "w+") == 0 || std::strcmp(mode, "r+") == 0;
+  bool write = std::strcmp(mode, "w+") == 0 || modify;
 
   verify(read || write, "open file mode not supported");
 
   DWORD access = read ? GENERIC_READ : GENERIC_READ | GENERIC_WRITE;
-  DWORD create_mode = read ? OPEN_EXISTING : CREATE_ALWAYS;
+  DWORD create_mode = modify ? OPEN_ALWAYS : read ? OPEN_EXISTING : CREATE_ALWAYS;
 
   auto const f = CreateFileA(path, access, FILE_SHARE_READ, nullptr,
                              create_mode, FILE_ATTRIBUTE_NORMAL, nullptr);


### PR DESCRIPTION
Currently, using r+ mode with open_file on Windows causes the file content to be erased. 
To prevent this, OPEN_ALWAYS should be used instead.
