### PR TITLE
atomic fetch_or, fetch_and, fetch_min, fetch_max

### DIFF
--- a/include/cista/atomic.h
+++ b/include/cista/atomic.h
@@ -52,7 +52,6 @@ inline std::int16_t fetch_max(std::int16_t& block, std::int16_t const val) {
     while (!a->compare_exchange_weak(old, std::max(old, val),
                                      std::memory_order_release,
                                      std::memory_order_relaxed)) {
-      ;
     }
   }
   return old;

--- a/include/cista/atomic.h
+++ b/include/cista/atomic.h
@@ -38,7 +38,6 @@ inline std::int16_t fetch_min(std::int16_t& block, std::int16_t const val) {
     while (!a->compare_exchange_weak(old, std::min(old, val),
                                      std::memory_order_release,
                                      std::memory_order_relaxed)) {
-      ;
     }
   }
   return old;

--- a/include/cista/atomic.h
+++ b/include/cista/atomic.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <cinttypes>
+#include <algorithm>
+#include <atomic>
+
+#if defined(_MSC_VER)
+#include "intrin.h"
+#endif
+
+namespace cista {
+
+inline std::uint64_t fetch_or(std::uint64_t& block, std::uint64_t const mask) {
+#if defined(_MSC_VER)
+  return _InterlockedOr64(reinterpret_cast<std::int64_t*>(&block), mask);
+#elif defined(__cpp_lib_atomic_ref)
+  return std::atomic_ref{block}.fetch_or(mask);
+#else
+  return __atomic_or_fetch(&block, mask, __ATOMIC_RELAXED);
+#endif
+}
+
+inline std::uint64_t fetch_and(std::uint64_t& block, std::uint64_t const mask) {
+#if defined(_MSC_VER)
+  return _InterlockedAnd64(reinterpret_cast<std::int64_t*>(&block), mask);
+#elif defined(__cpp_lib_atomic_ref)
+  return std::atomic_ref{block}.fetch_and(mask);
+#else
+  return __atomic_and_fetch(&block, mask, __ATOMIC_RELAXED);
+#endif
+}
+
+inline std::int16_t fetch_min(std::int16_t& block, std::int16_t const val) {
+  // UB due to aliasing but `std::atomic_ref` is not there yet.
+  auto const a = reinterpret_cast<std::atomic_int16_t*>(&block);
+  auto old = a->load();
+  if (old > val) {
+    while (!a->compare_exchange_weak(old, std::min(old, val),
+                                     std::memory_order_release,
+                                     std::memory_order_relaxed)) {
+      ;
+    }
+  }
+  return old;
+}
+
+inline std::int16_t fetch_max(std::int16_t& block, std::int16_t const val) {
+  // UB due to aliasing but `std::atomic_ref` is not there yet.
+  auto const a = reinterpret_cast<std::atomic_int16_t*>(&block);
+  auto old = a->load();
+  if (old > val) {
+    while (!a->compare_exchange_weak(old, std::max(old, val),
+                                     std::memory_order_release,
+                                     std::memory_order_relaxed)) {
+      ;
+    }
+  }
+  return old;
+}
+
+}  // namespace cista

--- a/include/cista/containers/bitvec.h
+++ b/include/cista/containers/bitvec.h
@@ -14,8 +14,8 @@
 
 #include "cista/bit_counting.h"
 #include "cista/containers/vector.h"
-#include "cista/cuda_check.h"
 #include "cista/strong.h"
+#include "cista/atomic.h"
 
 namespace cista {
 
@@ -98,37 +98,31 @@ struct basic_bitvec {
     }
   }
 
-#if __cpp_lib_atomic_ref
-  constexpr void atomic_set(
-      Key const i, bool const val = true,
-      std::memory_order succ = std::memory_order_seq_cst,
-      std::memory_order fail = std::memory_order_seq_cst) noexcept {
+  template <bool IsAtomic = false>
+  void set(Key const i, bool const val = true) noexcept {
     assert(i < size_);
     assert((to_idx(i) / bits_per_block) < blocks_.size());
-    auto const block = std::atomic_ref{
-        blocks_[static_cast<size_type>(to_idx(i)) / bits_per_block]};
+
     auto const bit = to_idx(i) % bits_per_block;
-
-    auto const update_block = [&](block_t const b) -> block_t {
+    auto& block = blocks_[static_cast<size_type>(to_idx(i)) / bits_per_block];
+    if constexpr (IsAtomic) {
       if (val) {
-        return block | (block_t{1U} << bit);
+        fetch_or(block, block_t{1U} << bit);
       } else {
-        return block & (~block_t{0U} ^ (block_t{1U} << bit));
+        fetch_and(block, (~block_t{0U} ^ (block_t{1U} << bit)));
       }
-    };
-
-    auto expected = block.load();
-    while (std::atomic_compare_exchange_weak(
-        &block, &expected, update_block(expected), succ, fail)) {
+    } else {
+      if (val) {
+        block |= (block_t{1U} << bit);
+      } else {
+        block &= (~block_t{0U} ^ (block_t{1U} << bit));
+      }
     }
   }
-#endif
 
   void reset() noexcept { blocks_ = {}; }
 
-  CISTA_CUDA_COMPAT bool operator[](Key const i) const noexcept {
-    return test(i);
-  }
+  bool operator[](Key const i) const noexcept { return test(i); }
 
   std::size_t count() const noexcept {
     if (empty()) {
@@ -235,7 +229,7 @@ struct basic_bitvec {
     }
   }
 
-  CISTA_CUDA_COMPAT size_type size() const noexcept { return size_; }
+  size_type size() const noexcept { return size_; }
   bool empty() const noexcept { return size() == 0U; }
 
   bool any() const noexcept {

--- a/include/cista/containers/bitvec.h
+++ b/include/cista/containers/bitvec.h
@@ -12,10 +12,10 @@
 #include <tuple>
 #include <type_traits>
 
+#include "cista/atomic.h"
 #include "cista/bit_counting.h"
 #include "cista/containers/vector.h"
 #include "cista/strong.h"
-#include "cista/atomic.h"
 
 namespace cista {
 

--- a/include/cista/hashing.h
+++ b/include/cista/hashing.h
@@ -8,6 +8,7 @@
 #include <string_view>
 #include <tuple>
 #include <type_traits>
+#include <variant>
 
 #include "cista/containers/cstring.h"
 #include "cista/containers/offset_ptr.h"

--- a/test/atomic_test.cc
+++ b/test/atomic_test.cc
@@ -1,6 +1,7 @@
 #include "doctest.h"
 
 #include <thread>
+#include <vector>
 
 #ifdef SINGLE_HEADER
 #include "cista.h"

--- a/test/atomic_test.cc
+++ b/test/atomic_test.cc
@@ -35,7 +35,7 @@ TEST_CASE("atomic min test") {
 
       while (true) {
         auto idx = next++;
-        if (idx > values.size()) {
+        if (idx >= values.size()) {
           return;
         }
         for (auto j = 0U; j != min.size(); ++j) {

--- a/test/atomic_test.cc
+++ b/test/atomic_test.cc
@@ -1,0 +1,57 @@
+#include "doctest.h"
+
+#include <thread>
+
+#ifdef SINGLE_HEADER
+#include "cista.h"
+#else
+#include "cista/atomic.h"
+#endif
+
+unsigned long get_random_number();
+
+TEST_CASE("atomic min test") {
+  constexpr auto const kNValues = 1'000'000;
+  constexpr auto const kWorkers = 100U;
+
+  auto values = std::vector<std::int16_t>{};
+  values.resize(kNValues);
+  std::generate(begin(values), end(values), [&]() {
+    return static_cast<std::int16_t>(get_random_number());
+  });
+
+  auto min = std::vector<std::int16_t>{};
+  min.resize(1000, std::numeric_limits<std::int16_t>::max());
+
+  auto workers = std::vector<std::thread>(kWorkers);
+  auto next = std::atomic_size_t{0U};
+  auto start = std::atomic_bool{false};
+  for (auto i = 0U; i != kWorkers; ++i) {
+    workers[i] = std::thread{[&]() {
+      while (!start) {
+        // wait for synchronized start
+      }
+
+      while (true) {
+        auto idx = next++;
+        if (idx > values.size()) {
+          return;
+        }
+        for (auto j = 0U; j != min.size(); ++j) {
+          cista::fetch_min(min[j], values[idx]);
+        }
+      }
+    }};
+  }
+
+  start.store(true);
+
+  for (auto& w : workers) {
+    w.join();
+  }
+
+  auto const smallest = *std::min_element(begin(values), end(values));
+  for (auto const& x : min) {
+    CHECK(x == smallest);
+  }
+}

--- a/test/bitvec_test.cc
+++ b/test/bitvec_test.cc
@@ -119,7 +119,7 @@ TEST_CASE("bitvec atomic set") {
         // wait for synchronized start
       }
 
-      for (auto j = i; j < kBits; j += kBits / kWorkers) {
+      for (auto j = i; j < kBits; j += kWorkers) {
         b.set<true>(j);
       }
     }};

--- a/test/bitvec_test.cc
+++ b/test/bitvec_test.cc
@@ -201,7 +201,7 @@ TEST_CASE("bitvec parallel mark store") {
     workers[i] = std::thread{[&]() {
       while (true) {
         auto idx = next++;
-        if (idx > bits.size()) {
+        if (idx >= bits.size()) {
           return;
         }
         b.template set<true>(static_cast<std::uint32_t>(bits[idx]), true);


### PR DESCRIPTION
based on UB - don't use without testing for your compiler + platform

will be replaced by `std::atomic_ref` as soon as available