### PR TITLE
Fix char_traits.h for C++17

### DIFF
--- a/include/cista/char_traits.h
+++ b/include/cista/char_traits.h
@@ -127,9 +127,11 @@ struct std_char_traits_helper {
 };
 
 template <typename CharT>
-using char_traits = std::conditional_t<
+using char_traits = typename std::conditional_t<
     std::disjunction_v<std::is_same<CharT, char>, std::is_same<CharT, wchar_t>,
+#if __cplusplus >= 201811L
                        std::is_same<CharT, char8_t>,
+#endif
                        std::is_same<CharT, char16_t>,
                        std::is_same<CharT, char32_t>>,
     std_char_traits_helper<CharT>, gen_char_traits_helper<CharT>>::value_type;


### PR DESCRIPTION
The char8_t type is only available if __cplusplus >= 201811L.

Fix the "implicit 'typename' is a C++20 extension" warning as well.