### PR TITLE
vector: fix move-assignment

### DIFF
--- a/include/cista/containers/vector.h
+++ b/include/cista/containers/vector.h
@@ -78,14 +78,16 @@ struct basic_vector {
   }
 
   basic_vector& operator=(basic_vector&& arr) noexcept {
-    deallocate();
+    if (&arr != this) {
+      deallocate();
 
-    el_ = arr.el_;
-    used_size_ = arr.used_size_;
-    self_allocated_ = arr.self_allocated_;
-    allocated_size_ = arr.allocated_size_;
+      el_ = arr.el_;
+      used_size_ = arr.used_size_;
+      self_allocated_ = arr.self_allocated_;
+      allocated_size_ = arr.allocated_size_;
 
-    arr.reset();
+      arr.reset();
+    }
     return *this;
   }
 


### PR DESCRIPTION
Move-assignment with the rvalue reference to the object itself should be no-op.