### PR TITLE
cstring, vector: fix memory leaks

### DIFF
--- a/include/cista/containers/cstring.h
+++ b/include/cista/containers/cstring.h
@@ -117,6 +117,7 @@ struct generic_cstring {
   }
 
   void move_from(generic_cstring&& s) noexcept {
+    reset();
     std::memcpy(static_cast<void*>(this), &s, sizeof(*this));
     if constexpr (std::is_pointer_v<Ptr>) {
       std::memset(static_cast<void*>(&s), 0, sizeof(*this));

--- a/include/cista/containers/vector.h
+++ b/include/cista/containers/vector.h
@@ -175,6 +175,7 @@ struct basic_vector {
         range_size >= 0 && range_size <= std::numeric_limits<size_type>::max(),
         "cista::vector::set: invalid range");
 
+    clear();
     reserve(static_cast<size_type>(range_size));
 
     auto copy_source = begin_it;


### PR DESCRIPTION
For cstring:
- reset() needs to be called when doing a move-assignment.

For vector:
- set() needs to call clear() to destroy the existing objects.