### PR TITLE
test: fix printable_test.cc and cista_members_test.cc

### DIFF
--- a/test/cista_members_test.cc
+++ b/test/cista_members_test.cc
@@ -41,7 +41,7 @@ namespace cista_members_printable {
 
 struct x {};
 struct a : public x {
-  CISTA_PRINTABLE(a)
+  CISTA_PRINTABLE(a, )
   auto cista_members() noexcept { return std::tie(a_, b_, c_); }
   int a_{1}, b_{2}, c_{3};
 };

--- a/test/printable_test.cc
+++ b/test/printable_test.cc
@@ -13,7 +13,7 @@ namespace {
 enum class Color : int { RED, BLUE, GREEN };
 
 struct a {
-  CISTA_PRINTABLE(a)
+  CISTA_PRINTABLE(a, )
   int i_ = 1;
   int j_ = 2;
   double d_ = 100.0;


### PR DESCRIPTION
Passing nothing for the variadic parameters of a macro is a C++20 extension.

This is an attempt to fix the CI failure.