### PR TITLE
reset memory_holder when not self_allocated

### DIFF
--- a/include/cista/memory_holder.h
+++ b/include/cista/memory_holder.h
@@ -20,7 +20,12 @@ struct wrapped {
   explicit wrapped(raw::unique_ptr<T> el) : el_{std::move(el)} {}
 
   void reset() {
-    el_.reset();
+    if (!el_.self_allocated_) {
+      el_->~T();
+      el_.el_ = nullptr;
+    } else {
+      el_.reset();
+    }
     if (std::holds_alternative<buffer>(mem_)) {
       std::get<buffer>(mem_) = buffer{};
     } else if (std::holds_alternative<byte_buf>(mem_)) {


### PR DESCRIPTION
Let's try again: When initialized by `cista::read`, `self_allocated_` is set to false (`el_.reset()` skips reset), but apparently we still need to free the members (as before), but the `el_.el_` itself is not heap-allocated (?). At least this appears to fix MOTIS imports both sanitized and unsanitized and with and without OSM.