### PR TITLE
fix the std::visit should return a value (#248)

### DIFF
--- a/include/cista/containers/variant.h
+++ b/include/cista/containers/variant.h
@@ -440,7 +440,7 @@ namespace std {
 
 template <typename Visitor, typename... T>
 constexpr auto visit(Visitor&& vis, cista::variant<T...>&& v) {
-  v.apply(vis);
+  return v.apply(std::forward<Visitor>(vis));
 }
 
 using cista::get;


### PR DESCRIPTION
Return a value for the function visit, and since function apply accepts a right-value reference, use std::forward for perfect forwarding.