### PR TITLE
fix: compute actual string length in set_owning heap path

### DIFF
--- a/include/cista/containers/string.h
+++ b/include/cista/containers/string.h
@@ -111,9 +111,13 @@ struct generic_string {
       if (h_.ptr_ == nullptr) {
         throw_exception(std::bad_alloc{});
       }
-      h_.size_ = len;
-      h_.self_allocated_ = true;
-      std::memcpy(data(), str, len * sizeof(CharT));
+      {
+        auto const str_len =
+            static_cast<msize_t>(std::char_traits<CharT>::length(str));
+        h_.size_ = str_len < len ? str_len : len;
+        h_.self_allocated_ = true;
+        std::memcpy(data(), str, h_.size_ * sizeof(CharT));
+      }
     }
   }
 


### PR DESCRIPTION
When `set_owning(str, len)` is called with a `len` larger than the actual null-terminated length of `str`, and the allocation falls on the heap path (`len > short_length_limit`), `h_.size_` was being set to the full `len` rather than the actual string length. This causes `size()` to report incorrect values.

Example: `set_owning("", 32)` would report `size() == 32` instead of `size() == 0` on the heap path, inconsistent with the short string path which correctly returns 0.

The fix computes the actual string length via `std::char_traits<CharT>::length(str)` and uses `min(actual_length, len)` for `h_.size_`, matching the behavior of the short string path.

Fixes #190.