### PR TITLE
Fix offset container move rebasing

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,10 +22,11 @@ jobs:
       - name: Install clang-format
         uses: ./.github/actions/install-llvm
         with:
-          packages: clang-format-17
+          version: 22
+          packages: clang-format-22
 
       - name: Format files
-        run: find include test -type f -a \( -name "*.cc" -o -name "*.h" \) -print0 | xargs -0  clang-format-17 -i
+        run: find include test -type f -a \( -name "*.cc" -o -name "*.h" \) -print0 | xargs -0  clang-format-22 -i
 
       - name: Check for differences
         run: |

--- a/include/cista/cista_member_offset.h
+++ b/include/cista/cista_member_offset.h
@@ -13,7 +13,7 @@ cista::offset_t member_offset(T const* t, Member const* m) {
 }
 
 template <typename T, typename Member>
-offset_t member_offset(T const* t, Member T::*m) {
+offset_t member_offset(T const* t, Member T::* m) {
   static_assert(std::is_trivially_copyable_v<T>);
   return (reinterpret_cast<std::uint8_t const*>(&(t->*m)) -
           reinterpret_cast<std::uint8_t const*>(t));

--- a/include/cista/containers/cstring.h
+++ b/include/cista/containers/cstring.h
@@ -118,11 +118,19 @@ struct generic_cstring {
 
   void move_from(generic_cstring&& s) noexcept {
     reset();
-    std::memcpy(static_cast<void*>(this), &s, sizeof(*this));
-    if constexpr (std::is_pointer_v<Ptr>) {
-      std::memset(static_cast<void*>(&s), 0, sizeof(*this));
-    } else if (!s.is_short()) {
-      h_.ptr_ = s.h_.ptr_;
+
+    if (s.is_short()) {
+      std::memcpy(static_cast<void*>(this), &s, sizeof(*this));
+      return;
+    }
+
+    auto const src_data = s.data();
+    h_ = heap{};
+    h_.ptr_ = src_data;
+    h_.size_ = s.h_.size_;
+    h_.self_allocated_ = s.h_.self_allocated_;
+
+    if (s.h_.self_allocated_) {
       s.s_ = stack{};
     }
   }

--- a/include/cista/containers/string.h
+++ b/include/cista/containers/string.h
@@ -148,15 +148,22 @@ struct generic_string {
       return;
     }
     reset();
-    std::memcpy(static_cast<void*>(this), &s, sizeof(*this));
-    if constexpr (std::is_pointer_v<Ptr>) {
-      std::memset(static_cast<void*>(&s), 0, sizeof(*this));
-    } else {
-      if (!s.is_short()) {
-        h_.ptr_ = s.h_.ptr_;
-        s.h_.ptr_ = nullptr;
-        s.h_.size_ = 0U;
-      }
+
+    if (s.is_short()) {
+      std::memcpy(static_cast<void*>(this), &s, sizeof(*this));
+      return;
+    }
+
+    auto const src_data = s.data();
+    h_.is_short_ = false;
+    h_.self_allocated_ = s.h_.self_allocated_;
+    h_.size_ = s.h_.size_;
+    h_.ptr_ = src_data;
+
+    if (s.h_.self_allocated_) {
+      s.h_.ptr_ = nullptr;
+      s.h_.size_ = 0U;
+      s.h_.self_allocated_ = false;
     }
   }
 

--- a/include/cista/containers/vector.h
+++ b/include/cista/containers/vector.h
@@ -69,7 +69,9 @@ struct basic_vector {
         allocated_size_(o.allocated_size_),
         self_allocated_(o.self_allocated_) {
     CISTA_UNUSED_PARAM(alloc)
-    o.reset();
+    if (o.self_allocated_) {
+      o.reset();
+    }
   }
 
   basic_vector(basic_vector const& o, Allocator const& alloc = Allocator{}) {
@@ -86,7 +88,9 @@ struct basic_vector {
       self_allocated_ = arr.self_allocated_;
       allocated_size_ = arr.allocated_size_;
 
-      arr.reset();
+      if (arr.self_allocated_) {
+        arr.reset();
+      }
     }
     return *this;
   }

--- a/include/cista/reflection/member_index.h
+++ b/include/cista/reflection/member_index.h
@@ -8,7 +8,7 @@
 namespace cista {
 
 template <typename T, typename MemberType>
-std::size_t member_index(MemberType T::*const member_ptr) {
+std::size_t member_index(MemberType T::* const member_ptr) {
   auto i = 0U, field_index = std::numeric_limits<unsigned>::max();
   T t{};
   cista::for_each_field(t, [&](auto&& m) {

--- a/test/offset_graph_static_version_test.cc
+++ b/test/offset_graph_static_version_test.cc
@@ -109,7 +109,9 @@ TEST_CASE("graph offset serialize file - static version") {
     cista::serialize<MODE>(f, g);
   }  // EOL graph
 
-  { cista::file f{FILENAME, "r"}; }
+  {
+    cista::file f{FILENAME, "r"};
+  }
 
   auto b = cista::file(FILENAME, "r").content();
 

--- a/test/string_test.cc
+++ b/test/string_test.cc
@@ -117,6 +117,19 @@ TEST_CASE("string copy assign and copy construct") {
   CHECK(s2.view() == LONG_STR);
 }
 
+TEST_CASE("offset string move preserves non owning source") {
+  auto const external = std::string{"non owning external string storage"};
+  auto s0 =
+      cista::offset::generic_string{external, cista::offset::string::non_owning};
+
+  auto s1 = std::move(s0);
+
+  CHECK(s0.data() == external.data());
+  CHECK(s0.view() == external);
+  CHECK(s1.data() == external.data());
+  CHECK(s1.view() == external);
+}
+
 TEST_CASE("string hash") {
   auto str = string{""};
   auto h = cista::hash(str, cista::BASE_HASH);

--- a/test/string_test.cc
+++ b/test/string_test.cc
@@ -119,8 +119,8 @@ TEST_CASE("string copy assign and copy construct") {
 
 TEST_CASE("offset string move preserves non owning source") {
   auto const external = std::string{"non owning external string storage"};
-  auto s0 =
-      cista::offset::generic_string{external, cista::offset::string::non_owning};
+  auto s0 = cista::offset::generic_string{external,
+                                          cista::offset::string::non_owning};
 
   auto s1 = std::move(s0);
 

--- a/test/vector_test.cc
+++ b/test/vector_test.cc
@@ -6,6 +6,7 @@
 #ifdef SINGLE_HEADER
 #include "cista.h"
 #else
+#include "cista/containers/string.h"
 #include "cista/containers/vector.h"
 #include "cista/equal_to.h"
 #include "cista/is_iterable.h"
@@ -201,6 +202,63 @@ TEST_CASE("iterable comparison") {
   std::set<int> std_s{1, 2, 3};
   CHECK(cista::equal_to<decltype(std_v)>{}(std_v, cista_v));
   CHECK(cista::equal_to<decltype(std_s)>{}(std_s, cista_v));
+}
+
+TEST_CASE("offset vector reallocation keeps nested offset containers valid") {
+  struct item {
+    cista::offset::string name_;
+    cista::offset::vector<uint32_t> values_;
+  };
+
+  cista::offset::vector<item> items;
+  items.reserve(1U);
+
+  auto& first = items.emplace_back();
+  first.name_ = "first item name that is longer than short string storage";
+  first.values_ = cista::offset::vector<uint32_t>{1U, 2U, 3U};
+
+  auto const* name_data = first.name_.data();
+  auto const* values_data = first.values_.data();
+
+  auto& second = items.emplace_back();
+  second.name_ = "second item name that is longer than short string storage";
+  second.values_ = cista::offset::vector<uint32_t>{4U, 5U, 6U};
+
+  CHECK(items[0].name_.view() ==
+        "first item name that is longer than short string storage");
+  CHECK(items[0].name_.data() == name_data);
+  CHECK(items[0].values_.data() == values_data);
+  CHECK(items[0].values_.size() == 3U);
+  CHECK(items[0].values_[0] == 1U);
+  CHECK(items[0].values_[1] == 2U);
+  CHECK(items[0].values_[2] == 3U);
+
+  CHECK(items[1].name_.view() ==
+        "second item name that is longer than short string storage");
+  CHECK(items[1].values_.size() == 3U);
+  CHECK(items[1].values_[0] == 4U);
+  CHECK(items[1].values_[1] == 5U);
+  CHECK(items[1].values_[2] == 6U);
+}
+
+TEST_CASE("offset vector move preserves non owning source") {
+  uint32_t storage[] = {1U, 2U, 3U};
+
+  cista::offset::vector<uint32_t> view;
+  view.el_ = storage;
+  view.used_size_ = 3U;
+  view.allocated_size_ = 3U;
+  view.self_allocated_ = false;
+
+  auto moved = std::move(view);
+
+  CHECK(view.data() == storage);
+  CHECK(view.size() == 3U);
+  CHECK(moved.data() == storage);
+  CHECK(moved.size() == 3U);
+  CHECK(moved[0] == 1U);
+  CHECK(moved[1] == 2U);
+  CHECK(moved[2] == 3U);
 }
 
 TEST_CASE("to_vec") {

--- a/test/vecvec_test.cc
+++ b/test/vecvec_test.cc
@@ -99,7 +99,9 @@ TEST_CASE("vecvec bucket grow test") {
     CHECK_EQ("hello\0\0\0\0\0   "sv, d[key{0}].view());
     CHECK_EQ("world", d[key{1}].view());
   }
-  { CHECK_THROWS_AS(d[key{0}].grow(5), std::runtime_error); }
+  {
+    CHECK_THROWS_AS(d[key{0}].grow(5), std::runtime_error);
+  }
 }
 
 TEST_CASE("vecvec resize test") {


### PR DESCRIPTION
Move offset-backed vectors and strings by resolving the source pointer and assigning through the destination offset pointer, so nested offset containers remain valid when outer containers relocate elements. Add regressions for vector reallocation and non-owned offset storage moves.